### PR TITLE
pass char functions instead of string functions to case-lisp-file

### DIFF
--- a/phoe-toolbox.lisp
+++ b/phoe-toolbox.lisp
@@ -622,8 +622,8 @@ value from the returned function."
 
 (defun upcase-lisp-file (pathname)
   "Upcases a Common Lisp source file."
-  (case-lisp-file pathname #'string-upcase))
+  (case-lisp-file pathname #'char-upcase))
 
 (defun downcase-lisp-file (pathname)
   "Downcases a Common Lisp source file."
-  (case-lisp-file pathname #'string-downcase))
+  (case-lisp-file pathname #'char-downcase))


### PR DESCRIPTION
i somehow didn't get this change committed before but the `write-char` in `case-lisp-file` isn't happy with the string functions passed in from the other functions.  the other option would of course be to use `princ` instead of `write-char`.